### PR TITLE
ステージ1 (クライアント情報のハッシュマップ化，タイムアウト処理)の実装

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,6 +1,7 @@
 import socket
 import threading
 import time
+import sys
 
 class UDPClient:
     def __init__(self, server_address, server_port):
@@ -9,6 +10,7 @@ class UDPClient:
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.client_address = ''
         self.client_port = self.find_free_port()
+        self.client_info = str(self.client_address)+ "," + str(self.client_port)
         self.sock.bind((self.client_address, self.client_port))
         self.username = ''
     
@@ -41,15 +43,22 @@ class UDPClient:
             usernamelen = len(self.username).to_bytes(1, byteorder='big')# UTF-8 エンコーディングを使用して変換 (指定されたバイト数（ここでは1バイト）のバイト列に変換します)
             data = usernamelen + self.username.encode() + message.encode() # ユーザー名とメッセージを結合して送信
             # サーバへのデータ送信
-            self.sock.sendto(data, (server_address, server_port))
+            self.sock.sendto(data, (self.server_address, self.server_port))
             time.sleep(0.1)
 
     # 他ユーザのメッセージの受信処理
     def receive_message(self):
         while True:
             rcv_data = self.sock.recvfrom(4096)[0].decode("utf-8")
-            print(rcv_data)
-             
+
+            if (rcv_data == "Timeout!"): # タイムアウト処理
+                print(rcv_data)
+                self.sock.close()
+                sys.exit()
+            else:
+                print(rcv_data)
+
+
     # 空きポートの割り当て
     def find_free_port(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -71,6 +80,7 @@ class UDPClient:
 
 
 if __name__ == "__main__":
+
     server_address = '0.0.0.0'
     server_port = 9001
     client = UDPClient(server_address, server_port)

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ class UDPServer:
                 print("新しいユーザーです -> ", name)
 
             else:
+                self.clientsmap[client_address][1] = time.time() # クライアントの最終送信時刻を更新
                 usernamelen = data[0] # 最初のバイトがユーザー名の長さを表す
                 username = data[1:usernamelen + 1].decode() # ユーザー名を取得
                 message = data[usernamelen + 1:].decode() # メッセージを取得
@@ -44,6 +45,8 @@ class UDPServer:
     # 各クライアントの最後のメッセ時送信時刻を追跡
     def send_time_tracking(self):
         while True:
+            time.sleep(60)# 1分単位で追跡
+            print("スリープ解除")
             try:
                 for address, value in self.clientsmap.items():
                     send_time = value[1]

--- a/server.py
+++ b/server.py
@@ -1,15 +1,13 @@
 import socket
-'''
-- アドレス情報をリストで保存しているが, ユーザー名とアドレスをハッシュマップで管理するように今後変更
-- 各クライアントの最後のメッセージ送信時刻を追跡する昨日は今後実装．
-
-'''
+import threading
+import time
 
 class UDPServer:
     def __init__(self, server_address, server_port):
         self.server_address = server_address
         self.server_port = server_port
-        self.clients = []
+        # self.clients = []
+        self.clientsmap = {}
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.bind((self.server_address, self.server_port))
         print("サーバが起動しました")
@@ -19,13 +17,17 @@ class UDPServer:
     # クライアントからのメッセージ受信処理 及び 他ユーザへの送信
     def handle_message(self):
         while True:
-            data, client_address = self.sock.recvfrom(4096) # 最大4096byteのデータを受信
 
+            data, client_address = self.sock.recvfrom(4096) # 最大4096byteのデータを受信
             # 新しいクライアントからの受信 -> clientsリストにアドレスを保存
-            if (not client_address in self.clients):
-                print("新しいユーザーです -> ", data.decode('utf-8'))
-                self.clients.append(client_address)
-                print(client_address)
+            if (not client_address in self.clientsmap):
+                name = data.decode('utf-8')
+                # print("新しいユーザーです -> ", name)
+                # self.clients.append(client_address)
+                self.clientsmap.update({client_address : [name, time.time()]})
+                #print(client_address)
+                #print("新しいユーザーです -> ", self.clientsmap[client_address], time.ctime())
+                print("新しいユーザーです -> ", name)
 
             else:
                 usernamelen = data[0] # 最初のバイトがユーザー名の長さを表す
@@ -36,16 +38,34 @@ class UDPServer:
     
     # リレーシステム
     def relay_message(self, message):
-        for client_address in self.clients:
+        for client_address in self.clientsmap.keys():
             self.sock.sendto(message.encode(), client_address)
+    
+    # 各クライアントの最後のメッセ時送信時刻を追跡
+    def send_time_tracking(self):
+        while True:
+            try:
+                for address, value in self.clientsmap.items():
+                    send_time = value[1]
+                    if (time.time() - send_time > 300): # クライアントからの通信が5分なければclientsmapから情報を削除
+                        self.clientsmap.pop(address)
+                        self.sock.sendto("Timeout!".encode(), address)
+                        print(value[0], address, "connection has been lost.")
+            except Exception as e: # ハッシュマップの中身がない時のエラー処理
+                pass
 
     def start(self):
-        self.handle_message()
+        thread_main = threading.Thread(target = self.handle_message)
+        thread_tracking = threading.Thread(target = self.send_time_tracking)
+        thread_main.start()
+        thread_tracking.start()
+        thread_main.join()
+        thread_tracking.join()
 
 if __name__ == "__main__":
     server_address = '0.0.0.0'
     server_port = 9001
     print('starting up on port {}'.format(server_port))
     server = UDPServer(server_address, server_port)
-    server.start()
 
+    server.start()


### PR DESCRIPTION
server.py
- アドレスとユーザー名をリスト管理からハッシュマップで管理に変更 clientsmap
- 各クライアントの送信時刻の追跡処理 send_time_traking()の実装
- リレーシステムからクライアントを削除する処理の実装

client.py
- recive_messege関数内にタイムアウト時にプログラムを終了する処理を実装